### PR TITLE
Set correct Tilde Key for ANSI Keyboard

### DIFF
--- a/US Intl PC without dead keys.bundle/Contents/Resources/US Intl without dead keys.keylayout
+++ b/US Intl PC without dead keys.bundle/Contents/Resources/US Intl without dead keys.keylayout
@@ -1,7 +1,7 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Inspired by https://altgr-weur.eu/altgr-intl.html#altgr, but replicated from https://github.com/riesinger/us-intl-altgr-dead-keys because it was more easy to extract the key mappings.&#x000A;&#x000A;dennis@paul.hamburg-->
-<!--Last edited by Ukelele version 396 on 2025-01-26 at 03:07 (GMT+1)-->
+<!--Last edited by Ukelele version 415 on 2025-03-16 at 13:04 (GMT+1)-->
 <keyboard group="126" id="-24656" name="US Intl without dead keys" maxout="1">
     <layouts>
         <layout first="0" last="17" mapSet="16c" modifiers="f4"/>
@@ -96,7 +96,7 @@
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="a5"/>
-            <key code="50" output="\"/>
+            <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -208,7 +208,7 @@
             <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="a5"/>
-            <key code="50" output="|"/>
+            <key code="50" output="~"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -396,7 +396,7 @@
             <key code="11" output=""/>
             <key code="12" output="ä"/>
             <key code="13" output="å"/>
-            <key code="14" output="é"/>
+            <key code="14" output="€"/>
             <key code="15" output="®"/>
             <key code="16" output="ü"/>
             <key code="17" output="þ"/>


### PR DESCRIPTION
Hi, first off, thanks for this repo! I was in pretty much the same situation as you.

There was one issue though, I have a Macbook with the US-ANSI keyboard (pipe key is above the return key). On that layout, the tilde key (left to the 1) and pipe key are switched (and there is no key between left shift and z).

I've included a CR for this kind of keyboard.